### PR TITLE
Repeat reading from websocket

### DIFF
--- a/public/opcua_client.lsp
+++ b/public/opcua_client.lsp
@@ -27,14 +27,14 @@ end
 
 local function opcUaClient(wsSock)
    local ok,uaClient
+   local js = require("JSONS").create({}, wsSock)
    while true do
-      local data,err = wsSock:read()
-      if not data then
-         tracep(false, 4, "WS close:" ,err)
+      local request, err = js:get()
+      if not request then
+         tracep(false, 1, "ERROR: Failed to read Request: ", err)
          break
       end
 
-      local request = ba.json.decode(data)
       if not request.id then
          tracep(false, 1, "ERROR: Request has no 'id': ", data)
          break

--- a/src/stores/UaState.ts
+++ b/src/stores/UaState.ts
@@ -34,11 +34,25 @@ export type UaStateType = {
 }
 
 function opcuaWebSockURL() {
+  // when we a in defelopment mode then
+  // web page is running inside vite dev server
+  // and the same time backed is running with mako: mako in linux usually
+  // runs on port 9357 and in windows on port 80
+  // if you have different ports then fix following URIes
+  if (process.env.NODE_ENV === 'development') {
+    const platform = navigator.userAgent.toLocaleLowerCase()
+    if (platform.indexOf("linux") >= 0) {
+      return 'ws://localhost:9357/opcua_client.lsp'
+    } else if (platform.indexOf("windows") >= 0){
+      return 'ws://localhost/opcua_client.lsp'
+    }
+  }
+
   const pos = window.location.pathname.lastIndexOf('/')
   const basePath = window.location.pathname.substring(0, pos)
   const host = window.location.hostname
   const protocol = window.location.protocol.replace("http", "ws")
-  const port = process.env.NODE_ENV === 'development' ? false : window.location.port
+  const port = window.location.port
   return `${protocol}//${host}${port ? ':'+port: ''}${basePath}/opcua_client.lsp`
 }
 


### PR DESCRIPTION
In Firefox browser the following code:
```
      local data,err,bytesRead,frameLength = wsSock:read()
      tracep(false, 1, tostring(data)..tostring(err)..tostring(byteRead)..tostring(frameLength))
```
prints next:
```
truenil1271
```
data is the empty string. In this case repeat reading from socket.
